### PR TITLE
Fixed error task 37 (socket hash error)

### DIFF
--- a/src/main/java/com/lotzy/skcrew/spigot/sockets/SocketClientListener.java
+++ b/src/main/java/com/lotzy/skcrew/spigot/sockets/SocketClientListener.java
@@ -122,7 +122,7 @@ public class SocketClientListener implements ClientListener {
             this.servers = infoPacket.getServers().entrySet().stream().map(entry -> 
             new SpigotServer(entry.getKey().getName(),entry.getKey().getInetSocketAddress(), entry.getValue().stream().map(player -> 
                 new SpigotPlayer(player.getName(),player.getUUID())).collect(Collectors.toCollection(HashSet::new)),entry.getKey().isConnected()))
-            .collect(Collectors.toCollection(HashSet::new));
+            .collect(Collectors.toSet());
             name = infoPacket.getName();
             Bukkit.getScheduler().runTask(Skcrew.getInstance(),() -> Bukkit.getPluginManager().callEvent(new ProxyConnectEvent(this.address)));
             isConnected = true;


### PR DESCRIPTION
Fixed this warn doing sockets dont connect to proxy: [19:11:48 WARN]: [Skcrew] Plugin Skcrew v3.6 generated an exception while executing task 37 java.lang.ClassCastException: class java.util.HashSet cannot be cast to class com.lotzy.skcrew.shared.sockets.data.BaseServer (java.util.HashSet is in module java.base of loader 'bootstrap'; com.lotzy.skcrew.shared.sockets.data.BaseServer is in unnamed module of loader 'Skcrew.jar' @6a3a0425)